### PR TITLE
Add option for service name and ensure started

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 vpn_gateway_service: strongswan
 vpn_gateway_config_dir: "/etc/ipsec.d/{{ role_name }}"
 vpn_gateway_configs: []
+vpn_gateway_cacerts: []
 vpn_gateway_default_config_params:
   type: tunnel
   keyingtries: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+vpn_gateway_service: strongswan
 vpn_gateway_config_dir: "/etc/ipsec.d/{{ role_name }}"
 vpn_gateway_configs: []
 vpn_gateway_default_config_params:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart ipsec
   service:
-    name: strongswan
+    name: "{{ vpn_gateway_service }}"
     state: restarted
 
 - name: reload ipsec

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -72,4 +72,16 @@
     owner: root
     group: root
     mode: 0600
-  notify: reload ipsec
+  notify: restart ipsec
+
+- name: Copy ca certs
+  copy:
+    content: "{{ item.content }}"
+    dest: "/etc/ipsec.d/cacert/{{ name }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ vpn_gateway_cacerts }}"
+  loop_control:
+    label: "{{ item.name }}"
+  notify: restart ipsec

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -77,7 +77,7 @@
 - name: Copy ca certs
   copy:
     content: "{{ item.content }}"
-    dest: "/etc/ipsec.d/cacert/{{ name }}"
+    dest: "/etc/ipsec.d/cacert/{{ item.name }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -77,7 +77,7 @@
 - name: Copy ca certs
   copy:
     content: "{{ item.content }}"
-    dest: "/etc/ipsec.d/cacert/{{ item.name }}"
+    dest: "/etc/ipsec.d/cacerts/{{ item.name }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,5 +6,6 @@
 
 - name: IPSec must be running
   service:
-    name: strongswan
+    name: "{{ vpn_gateway_service }}"
     state: started
+    enabled: yes

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -20,5 +20,7 @@
   assert:
     that: item.psk | length > 0
     fail_msg: "Variable 'psk' is not correct for vpn_gateway_configs with name: {{ item.name }}"
-  when: (item.state | default('present')) == 'present'
+  when:
+    - (item.state | default('present')) == 'present'
+    - item.private_key is not defined
   loop: "{{ vpn_gateway_configs }}"

--- a/templates/ipsec.conf.j2
+++ b/templates/ipsec.conf.j2
@@ -4,6 +4,8 @@
 # {{ connection.left }} -> {{ connection.right }}
 conn {{ connection.name }}
 {% for param_key in connection %}
+{% if param_key != 'name' %}
     {{ param_key }}={{ connection[param_key] }}
+{% endif %}
 {% endfor %}
 {% endfor %}

--- a/templates/ipsec.secrets.j2
+++ b/templates/ipsec.secrets.j2
@@ -2,6 +2,11 @@
 
 {% for config in vpn_gateway_configs %}
 {% if (config.state | default('present')) == 'present' %}
+{% if config.psk is defined %}
 {{ config.local.public }} {{ config.remote.public }} : PSK {{ config.psk }}
+{% endif %}
+{% if config.private_key is defined %}
+: RSA {{ config.private_key }}
+{% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
On Ubuntu 20.04 the service name for strongswan is `strongswan-starter`. This PR makes the service name configurable via defaults.